### PR TITLE
Bump `libpg-query` depedency to 13.1.2

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "libpg-query": "13.1.1",
+    "libpg-query": "13.1.2",
     "minimist": "^1.2.5",
     "pgsql-deparser": "^13.1.12",
     "pgsql-enums": "^13.1.2"


### PR DESCRIPTION
https://github.com/pyramation/libpg-query-node/pull/10

Has a fix for M1 macs that I believe should fix the issues I was having