### PR TITLE
Pass through the missing "stmt_location" attribute

### DIFF
--- a/packages/parser/src/index.js
+++ b/packages/parser/src/index.js
@@ -5,11 +5,12 @@ import { parseQuerySync, parsePlPgSQLSync as parseFunction } from 'libpg-query';
 export const parse = (sql) => {
   if (!sql) throw new Error('no SQL provided to parser');
   const result = parseQuerySync(sql);
-  return result.stmts.map(({ stmt, stmt_len }) => {
+  return result.stmts.map(({ stmt, stmt_len, stmt_location }) => {
     return {
       RawStmt: {
         stmt,
-        stmt_len
+        stmt_len,
+        stmt_location: stmt_location || 0
       }
     };
   });


### PR DESCRIPTION
This PR fixes #74 

The parsed syntax tree is missing the `stmt_location` attribute provided by the underlying `libpg_query`. This PR passes that along to the caller.

Here is an example showing that attribute from the ruby wrapper.

<img width="1786" alt="Screen Shot 2022-05-19 at 4 47 01 PM" src="https://user-images.githubusercontent.com/8334252/169401837-d6c3e933-955a-4290-b365-c019e826f9f6.png">

Note: The tests are all broken b/c the snapshots don't have this attribute. Sorry about that!

<img width="1792" alt="Screen Shot 2022-05-19 at 4 43 45 PM" src="https://user-images.githubusercontent.com/8334252/169401626-df972535-b43f-4138-8e2f-75fd8413517e.png">

