### PR TITLE
Get all CTE tests passing

### DIFF
--- a/__fixtures__/upstream/with.sql
+++ b/__fixtures__/upstream/with.sql
@@ -32,19 +32,19 @@ UNION ALL
 SELECT * FROM t;
 
 -- recursive view
-CREATE RECURSIVE VIEW nums (n) AS
-    VALUES (1)
-UNION ALL
-    SELECT n+1 FROM nums WHERE n < 5;
+-- CREATE RECURSIVE VIEW nums (n) AS
+    -- VALUES (1)
+-- UNION ALL
+    -- SELECT n+1 FROM nums WHERE n < 5;
 
-SELECT * FROM nums;
+-- SELECT * FROM nums;
 
-CREATE OR REPLACE RECURSIVE VIEW nums (n) AS
-    VALUES (1)
-UNION ALL
-    SELECT n+1 FROM nums WHERE n < 6;
+-- CREATE OR REPLACE RECURSIVE VIEW nums (n) AS
+    -- VALUES (1)
+-- UNION ALL
+    -- SELECT n+1 FROM nums WHERE n < 6;
 
-SELECT * FROM nums;
+-- SELECT * FROM nums;
 
 -- This is an infinite loop with UNION ALL, but not with UNION
 WITH RECURSIVE t(n) AS (

--- a/__fixtures__/upstream/with.sql
+++ b/__fixtures__/upstream/with.sql
@@ -32,19 +32,19 @@ UNION ALL
 SELECT * FROM t;
 
 -- recursive view
--- CREATE RECURSIVE VIEW nums (n) AS
-    -- VALUES (1)
--- UNION ALL
-    -- SELECT n+1 FROM nums WHERE n < 5;
+CREATE RECURSIVE VIEW nums (n) AS
+    VALUES (1)
+UNION ALL
+    SELECT n+1 FROM nums WHERE n < 5;
 
--- SELECT * FROM nums;
+SELECT * FROM nums;
 
--- CREATE OR REPLACE RECURSIVE VIEW nums (n) AS
-    -- VALUES (1)
--- UNION ALL
-    -- SELECT n+1 FROM nums WHERE n < 6;
+CREATE OR REPLACE RECURSIVE VIEW nums (n) AS
+    VALUES (1)
+UNION ALL
+    SELECT n+1 FROM nums WHERE n < 6;
 
--- SELECT * FROM nums;
+SELECT * FROM nums;
 
 -- This is an infinite loop with UNION ALL, but not with UNION
 WITH RECURSIVE t(n) AS (

--- a/packages/deparser/__tests__/kitchen-sink.test.js
+++ b/packages/deparser/__tests__/kitchen-sink.test.js
@@ -776,7 +776,7 @@ describe('kitchen sink', () => {
     xit('upstream/window.sql', () => {
       check('upstream/window.sql');
     });
-    xit('upstream/with.sql', () => {
+    it('upstream/with.sql', () => {
       check('upstream/with.sql');
     });
     xit('upstream/without_oid.sql', () => {

--- a/packages/deparser/__tests__/kitchen-sink.test.js
+++ b/packages/deparser/__tests__/kitchen-sink.test.js
@@ -679,7 +679,7 @@ describe('kitchen sink', () => {
     xit('upstream/triggers.sql', () => {
       check('upstream/triggers.sql');
     });
-    xit('upstream/truncate.sql', () => {
+    it('upstream/truncate.sql', () => {
       check('upstream/truncate.sql');
     });
     xit('upstream/tsdicts.sql', () => {

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -166,6 +166,18 @@ export default class Deparser {
     });
   }
 
+  deparseReturningList(list, context) {
+    return list
+      .map(
+        (returning) =>
+          this.deparse(returning.ResTarget.val, context) +
+          (returning.ResTarget.name
+            ? ' AS ' + this.quote(returning.ResTarget.name)
+            : '')
+      )
+      .join(',');
+  }
+
   list(nodes, separator = ', ', prefix = '', context) {
     if (!nodes) {
       return '';
@@ -1455,17 +1467,7 @@ export default class Deparser {
 
     if (node.returningList) {
       output.push('RETURNING');
-      output.push(
-        node.returningList
-          .map(
-            (returning) =>
-              this.deparse(returning.ResTarget.val, context) +
-              (returning.ResTarget.name
-                ? ' AS ' + this.quote(returning.ResTarget.name)
-                : '')
-          )
-          .join(',')
-      );
+      output.push(this.deparseReturningList(node.returningList, context));
     }
 
     return output.join(' ');
@@ -1491,9 +1493,22 @@ export default class Deparser {
     output.push('DELETE');
     output.push('FROM');
     output.push(this.RangeVar(node.relation, context));
+
+    if (node.usingClause) {
+      output.push('USING');
+      output.push(
+        node.usingClause.map((e) => this.deparse(e, context)).join(', ')
+      );
+    }
+
     if (node.whereClause) {
       output.push('WHERE');
       output.push(this.deparse(node.whereClause, context));
+    }
+
+    if (node.returningList) {
+      output.push('RETURNING');
+      output.push(this.deparseReturningList(node.returningList, context));
     }
     return output.join(' ');
   }
@@ -1546,17 +1561,7 @@ export default class Deparser {
 
     if (node.returningList) {
       output.push('RETURNING');
-      output.push(
-        node.returningList
-          .map(
-            (returning) =>
-              this.deparse(returning.ResTarget.val, context) +
-              (returning.ResTarget.name
-                ? ' AS ' + this.quote(returning.ResTarget.name)
-                : '')
-          )
-          .join(',')
-      );
+      output.push(this.deparseReturningList(node.returningList, context));
     }
 
     return output.join(' ');

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -1236,6 +1236,10 @@ export default class Deparser {
             return `${name} ${this.deparse(node.arg, 'simple')}`;
           }
       }
+    } else if (context === 'explain') {
+      if (node.arg) {
+        return `${name} ${this.deparse(node.arg)}`;
+      }
     } else if (node.arg) {
       return `${name} = ${this.deparse(node.arg, context)}`;
     }
@@ -1892,6 +1896,11 @@ export default class Deparser {
   ['ExplainStmt'](node, context = {}) {
     const output = [];
     output.push('EXPLAIN');
+    if (node.options) {
+      output.push('(');
+      output.push(this.list(node.options, ', ', '', 'explain'));
+      output.push(')');
+    }
     output.push(this.deparse(node.query, context));
     return output.join(' ');
   }

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -1824,7 +1824,7 @@ export default class Deparser {
       output.push('ONLY');
     }
 
-    if (!node.inh && context.lock) {
+    if (!node.inh && (context.lock || context === 'truncate')) {
       output.push('ONLY');
     }
 
@@ -2037,6 +2037,22 @@ export default class Deparser {
       node.lockingClause.forEach((item) => {
         return output.push(this.deparse(item, context));
       });
+    }
+
+    return output.join(' ');
+  }
+
+  ['TruncateStmt'](node, context = {}) {
+    const output = ['TRUNCATE TABLE'];
+
+    output.push(node.relations.map((e) => this.deparse(e, 'truncate')).join(', '));
+
+    if (node.restart_seqs) {
+      output.push('RESTART IDENTITY');
+    }
+
+    if (node.behavior === 'DROP_CASCADE') {
+      output.push('CASCADE');
     }
 
     return output.join(' ');

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -2783,7 +2783,7 @@ export default class Deparser {
     );
     output.push(`${NEWLINE_CHAR})`);
 
-    if (relpersistence === 'p' && node.hasOwnProperty('inhRelations')) {
+    if (node.hasOwnProperty('inhRelations')) {
       output.push('INHERITS');
       output.push('(');
       output.push(this.list(node.inhRelations, ', ', '', context));

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -1408,6 +1408,10 @@ export default class Deparser {
   ['InsertStmt'](node, context = {}) {
     const output = [];
 
+    if (node.withClause) {
+      output.push(this.WithClause(node.withClause, context));
+    }
+
     output.push('INSERT INTO');
     output.push(this.RangeVar(node.relation, context));
 
@@ -1479,6 +1483,11 @@ export default class Deparser {
 
   ['DeleteStmt'](node, context = {}) {
     const output = [''];
+
+    if (node.withClause) {
+      output.push(this.WithClause(node.withClause, context));
+    }
+
     output.push('DELETE');
     output.push('FROM');
     output.push(this.RangeVar(node.relation, context));
@@ -1491,6 +1500,11 @@ export default class Deparser {
 
   ['UpdateStmt'](node, context = {}) {
     const output = [];
+
+    if (node.withClause) {
+      output.push(this.WithClause(node.withClause, context));
+    }
+
     output.push('UPDATE');
     if (node.relation) {
       // onConflictClause no relation..

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -334,14 +334,13 @@ export default class Deparser {
     }
     output.push('TO');
     output.push(this.RangeVar(node.relation, context));
-    if (node.instead) {
-      output.push('DO');
-      output.push('INSTEAD');
-    }
     if (node.whereClause) {
       output.push('WHERE');
       output.push(this.deparse(node.whereClause, context));
-      output.push('DO');
+    }
+    output.push('DO');
+    if (node.instead) {
+      output.push('INSTEAD');
     }
     if (!node.actions || !node.actions.length) {
       output.push('NOTHING');

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -1499,9 +1499,7 @@ export default class Deparser {
 
     if (node.usingClause) {
       output.push('USING');
-      output.push(
-        node.usingClause.map((e) => this.deparse(e, context)).join(', ')
-      );
+      output.push(this.list(node.usingClause, ', ', '', context));
     }
 
     if (node.whereClause) {
@@ -1696,9 +1694,7 @@ export default class Deparser {
   ['LockStmt'](node, context = {}) {
     const output = ['LOCK'];
 
-    output.push(
-      node.relations.map((e) => this.deparse(e, { lock: true })).join(', ')
-    );
+    output.push(this.list(node.relations, ', ', '', { lock: true }));
     output.push('IN');
     output.push(LOCK_MODES[node.mode]);
     output.push('MODE');
@@ -2070,7 +2066,7 @@ export default class Deparser {
   ['TruncateStmt'](node, context = {}) {
     const output = ['TRUNCATE TABLE'];
 
-    output.push(node.relations.map((e) => this.deparse(e, 'truncate')).join(', '));
+    output.push(this.list(node.relations, ', ', '', 'truncate'));
 
     if (node.restart_seqs) {
       output.push('RESTART IDENTITY');
@@ -2583,7 +2579,7 @@ export default class Deparser {
     output.push(this.RangeVar(node.view, 'view'));
     if (node.aliases) {
       output.push('(');
-      output.push(this.list(node.aliases, ', ', '', context))
+      output.push(this.list(node.aliases, ', ', '', context));
       output.push(')');
     }
     output.push('AS');

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -1041,12 +1041,10 @@ export default class Deparser {
     output.push(node.ctename);
 
     if (node.aliascolnames) {
-      output.push(
-        format(
-          '(%s)',
-          this.quote(this.deparseNodes(node.aliascolnames, context))
-        )
+      const colnames = this.quote(
+        this.deparseNodes(node.aliascolnames, context)
       );
+      output.push(`(${colnames.join(', ')})`);
     }
 
     output.push(format('AS (%s)', this.deparse(node.ctequery)));

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -2581,6 +2581,11 @@ export default class Deparser {
     }
     output.push('VIEW');
     output.push(this.RangeVar(node.view, 'view'));
+    if (node.aliases) {
+      output.push('(');
+      output.push(this.list(node.aliases, ', ', '', context))
+      output.push(')');
+    }
     output.push('AS');
     output.push(this.deparse(node.query, context));
     if (node.withCheckOption === 'LOCAL_CHECK_OPTION') {


### PR DESCRIPTION
This PR is a superset of #83 (TRUNCATE being implemented is needed), and it adds the `with.sql` fixture file to the kitchen sink tests. I fixed the following bugs in order to get the rest of the file working...

1. fix list of column aliases in a CTE, e.g.
 This query:
```sql
WITH q1(x,y) AS (SELECT 1,2)
SELECT * FROM q1, q1 AS q2
```
Was producing this invalid result:
```sql
WITH q1 ([ 'x', 'y' ]) AS (SELECT 1,2)
SELECT * FROM q1,
q1 AS q2;
```
2. fix creation of temporary VIEWs, e.g.
This query:
```sql
      CREATE TEMPORARY VIEW vsubdepartment AS
      	WITH RECURSIVE subdepartment AS
      	(
      		 -- non recursive term
      		SELECT * FROM department WHERE name = 'A'
      		UNION ALL
      		-- recursive term
      		SELECT d.* FROM department AS d, subdepartment AS sd
      			WHERE d.parent_department = sd.id
      	)
      	SELECT * FROM subdepartment
```
was producing this invalid result:
```sql
      CREATE VIEW TEMPORARY TABLE vsubdepartment AS WITH RECURSIVE subdepartment AS ((SELECT * FROM department WHERE name = 'A') UNION ALL (SELECT d.* FROM department AS d,
      subdepartment AS sd WHERE d.parent_department = sd.id)) SELECT * FROM subdepartment;
```
3. fix WITH clauses not getting added to UPDATE, DELETE, INSERT statements, e.g.
this query:
```sql
      WITH t AS (
      	SELECT a FROM y
      )
      INSERT INTO y
      SELECT a+20 FROM t RETURNING *
```
was producing this invalid result:
```sql
      INSERT INTO y SELECT a + 20 FROM t RETURNING *;
```
4. fix USING and RETURNING clauses getting omitted from DELETE statements, e.g.
this query:
```sql
      WITH RECURSIVE t(a) AS (
      	SELECT 11
      	UNION ALL
      	SELECT a+1 FROM t WHERE a < 50
      )
      DELETE FROM y USING t WHERE t.a = y.a RETURNING y.a
```
was producing this invalid result:
```sql
       WITH RECURSIVE t (a) AS ((SELECT 11) UNION ALL (SELECT a + 1 FROM t WHERE a < 50)) DELETE FROM y WHERE t.a = y.a;
```
5. fix INHERITS getting omitted for temp table, e.g.
this query:
```sql
      CREATE TEMP TABLE child1 ( ) INHERITS ( parent )
```
was producing this invalid result:
```sql
      CREATE TEMPORARY TABLE child1 ()
```
6. fix missing options on EXPLAIN, e.g.
this query:
```sql
      EXPLAIN (VERBOSE, COSTS OFF)
      WITH wcte AS ( INSERT INTO int8_tbl VALUES ( 42, 47 ) RETURNING q2 )
      DELETE FROM a USING wcte WHERE aa = q2
```
was producing this invalid result:
```sql
      EXPLAIN  WITH wcte AS (INSERT INTO int8_tbl VALUES (42, 47) RETURNING q2) DELETE FROM a USING wcte WHERE aa = q2;
```
7. fix bug in RuleStmt, e.g.
this query:
```sql
      CREATE RULE y_rule AS ON INSERT TO y WHERE a=0 DO INSTEAD DELETE FROM y
```
was producing this invalid result:
```sql
      CREATE RULE y_rule AS ON INSERT TO y DO INSTEAD WHERE a = 0 DO  DELETE FROM y;
```
8. Aliases getting omitted from `CREATE VIEW` statements.
