### PR TITLE
Add support for cte materialization

### DIFF
--- a/__fixtures__/statements/cte.sql
+++ b/__fixtures__/statements/cte.sql
@@ -1,0 +1,20 @@
+WITH regional_sales AS (
+        SELECT region, SUM(amount) AS total_sales
+        FROM orders
+        GROUP BY region
+     ), top_regions AS NOT MATERIALIZED (
+        SELECT region
+        FROM regional_sales
+        WHERE total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)
+     ), flop_regions AS MATERIALIZED (
+        SELECT region
+        FROM regional_sales
+        WHERE total_sales < (SELECT SUM(total_sales)/10 FROM regional_sales)
+     )
+SELECT region,
+       product,
+       SUM(quantity) AS product_units,
+       SUM(amount) AS product_sales
+FROM orders
+WHERE region IN (SELECT region FROM top_regions) OR region IN (SELECT region FROM flop_regions)
+GROUP BY region, product;

--- a/__fixtures__/statements/select.sql
+++ b/__fixtures__/statements/select.sql
@@ -2,7 +2,7 @@ WITH regional_sales AS (
         SELECT region, SUM(amount) AS total_sales
         FROM orders
         GROUP BY region
-     ), top_regions AS NOT MATERIALIZED (
+     ), top_regions AS (
         SELECT region
         FROM regional_sales
         WHERE total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)
@@ -15,7 +15,7 @@ FROM orders
 WHERE region IN (SELECT region FROM top_regions)
 GROUP BY region, product;
 
-with chars2bits AS MATERIALIZED (
+with chars2bits AS (
     select
         character,
         (index - 1)::bit(5)::text AS index

--- a/__fixtures__/statements/select.sql
+++ b/__fixtures__/statements/select.sql
@@ -2,7 +2,7 @@ WITH regional_sales AS (
         SELECT region, SUM(amount) AS total_sales
         FROM orders
         GROUP BY region
-     ), top_regions AS (
+     ), top_regions AS NOT MATERIALIZED (
         SELECT region
         FROM regional_sales
         WHERE total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)
@@ -15,7 +15,7 @@ FROM orders
 WHERE region IN (SELECT region FROM top_regions)
 GROUP BY region, product;
 
-with chars2bits AS (
+with chars2bits AS MATERIALIZED (
     select
         character,
         (index - 1)::bit(5)::text AS index

--- a/packages/deparser/__tests__/kitchen-sink.test.js
+++ b/packages/deparser/__tests__/kitchen-sink.test.js
@@ -168,6 +168,9 @@ describe('kitchen sink', () => {
   it('select', () => {
     check('statements/select.sql');
   });
+  it('cte', () => {
+    check('statements/cte.sql');
+  });
   it('conflicts', () => {
     check('statements/conflicts.sql');
   });

--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -1058,7 +1058,14 @@ export default class Deparser {
       output.push(`(${colnames.join(', ')})`);
     }
 
-    output.push(format('AS (%s)', this.deparse(node.ctequery)));
+    output.push('AS');
+    if (node.ctematerialized === 'CTEMaterializeAlways') {
+      output.push('MATERIALIZED');
+    } else if (node.ctematerialized === 'CTEMaterializeNever') {
+      output.push('NOT MATERIALIZED');
+    }
+
+    output.push(format('(%s)', this.deparse(node.ctequery)));
 
     return output.join(' ');
   }


### PR DESCRIPTION
Currently, CTE materialization is dropped. This retains the materialization modifier for CTEs.