### PR TITLE
Update deparser.js for ALL caps needsQuotes

### DIFF
--- a/packages/deparser/src/deparser.js
+++ b/packages/deparser/src/deparser.js
@@ -109,7 +109,7 @@ const LOCK_MODES = {
 const isReserved = (value) => RESERVED_WORDS.has(value.toLowerCase());
 
 // has uppercase and lowercase, or non word characters
-const needsQuotesRegex = /[a-z]+[\W\w]*[A-Z]+|[A-Z]+[\W\w]*[a-z]+|\W/;
+const needsQuotesRegex = /[a-z]+[\W\w]*[A-Z]+|[A-Z]+[\W\w]*[a-z]+|\W|[A-Z]/;
 
 // usually the AST lowercases all the things, so if we
 // have both, the author most likely used double quotes


### PR DESCRIPTION
the needsQuotes check regex fails when the input is all caps like A, AA, AAAA

related issue https://github.com/pyramation/pgsql-parser/issues/101