### PR TITLE
fix: support create index if not exists

### DIFF
--- a/__fixtures__/misc.sql
+++ b/__fixtures__/misc.sql
@@ -19,4 +19,6 @@ create table if not exists users (
   handle text not null,
   created_at timestamp not null default now(),
   updated_at timestamp not null default now()
-)
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS index_email_logs_on_created_at ON public.email_logs USING btree (created_at DESC);

--- a/packages/deparser/src/deparser.ts
+++ b/packages/deparser/src/deparser.ts
@@ -1510,6 +1510,9 @@ export default class Deparser {
     if (node.concurrent) {
       output.push('CONCURRENTLY');
     }
+    if (node.if_not_exists) {
+      output.push('IF NOT EXISTS');
+    }
 
     if (node.idxname) {
       output.push(node.idxname);


### PR DESCRIPTION
The flag `if_not_exists` was ignored when deparsing a create index statement.