### PR TITLE
fix: Use `@pgsql/enums` package in Deparser

### DIFF
--- a/packages/deparser/package.json
+++ b/packages/deparser/package.json
@@ -84,6 +84,6 @@
   "dependencies": {
     "@pgsql/types": "^13.9.0",
     "dotty": "^0.1.0",
-    "pgsql-enums": "^13.10.0"
+    "@pgsql/enums": "^13.9.0"
   }
 }

--- a/packages/deparser/src/deparser.ts
+++ b/packages/deparser/src/deparser.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { format } from 'util';
-import { objtypeName, getConstraintFromConstrType } from 'pgsql-enums';
+import { objtypeName, getConstraintFromConstrType } from '@pgsql/enums';
 import { 
   A_ArrayExpr, 
   A_Const, 


### PR DESCRIPTION
The `pgsql-enums` package generates invalid Typescript definitions, so we're updating the deparser to use the new `@pgsql/enums` package, which works as expected.