### PR TITLE
fix: update `pgsql-enums` JSON import paths

### DIFF
--- a/packages/pgsql-enums/types/index.d.ts
+++ b/packages/pgsql-enums/types/index.d.ts
@@ -1,6 +1,6 @@
-import toInt from './enums2int.json';
-import toStr from './enums2str.json';
-import nodes from './nodes.json';
+import toInt from '../src/enums2int.json';
+import toStr from '../src/enums2str.json';
+import nodes from '../src/nodes.json';
 export { toInt, toStr, nodes };
 export declare const getEnum: (enumType: any, key: any) => any;
 export * from './types';


### PR DESCRIPTION
In newer versions of Typescript, the compiler will throw an error because the `index.d.ts` file references JSON files in the wrong path.

This way, we make it point at the `../src` folder, where they are packaged, even in the final build.