### PR TITLE
fix: preserve num field in AlterTableCmd 14->15 transformation

### DIFF
--- a/packages/transform/src/transformers/v14-to-v15.ts
+++ b/packages/transform/src/transformers/v14-to-v15.ts
@@ -786,6 +786,10 @@ export class V14ToV15Transformer {
       result.name = node.name;
     }
 
+    if (node.num !== undefined) {
+      result.num = node.num;
+    }
+
     if (node.newowner !== undefined) {
       result.newowner = this.transform(node.newowner as any, context);
     }

--- a/packages/transform/test-utils/skip-tests/transformer-errors.ts
+++ b/packages/transform/test-utils/skip-tests/transformer-errors.ts
@@ -22,7 +22,7 @@ export const transformerErrors: SkipTest[] = [
     [15, 16, "latest/postgres/create_index-326.sql", "15-16 transformer fails with syntax error at end of input"],
     [15, 16, "latest/postgres/create_index-184.sql", "15-16 transformer fails with missing nulls_not_distinct property"],
 
-    [14, 15, "latest/postgres/create_index-345.sql", "AST transformation mismatch (extra \"num\": 1 field)"],
+    // [14, 15, "latest/postgres/create_index-345.sql", "AST transformation mismatch (extra \"num\": 1 field)"],
 
     [13, 14, "original/upstream/rangetypes-300.sql", "AST transformer bug - converts FUNC_PARAM_DEFAULT to FUNC_PARAM_IN for function parameters"],
     [13, 14, "original/upstream/rangetypes-294.sql", "AST transformer bug - converts FUNC_PARAM_DEFAULT to FUNC_PARAM_IN for function parameters"],
@@ -93,4 +93,4 @@ export const transformerErrors: SkipTest[] = [
     [13, 14, "latest/postgres/create_function_sql-91.sql", "AST transformer bug - converts FUNC_PARAM_DEFAULT to FUNC_PARAM_IN in CREATE FUNCTION statements with default parameter values"],
     [13, 14, "latest/postgres/create_function_sql-90.sql", "AST transformer bug - converts FUNC_PARAM_DEFAULT to FUNC_PARAM_IN in CREATE FUNCTION statements with default parameter values"],
     [13, 14, "latest/postgres/create_function_sql-115.sql", "AST transformer bug - incorrectly adds parameter names to objfuncargs in DROP FUNCTION statements"],
-]; 
+];  


### PR DESCRIPTION

# Fix: preserve num field in AlterTableCmd 14->15 transformation

## Summary

Fixed an AST transformation mismatch where the `num` field was being dropped during PostgreSQL 14 to 15 AST transformation for ALTER INDEX statements. The issue occurred in the `AlterTableCmd` transformation method which was explicitly preserving only certain fields but missing the `num` field.

**Root cause**: The `AlterTableCmd` method in `v14-to-v15.ts` had conditional field preservation logic but was missing handling for the `num` field, causing it to be dropped during transformation even though both PG14 and PG15 should have identical AST structures for this statement type.

**Changes made**:
- Added `num` field preservation in `AlterTableCmd` transformation method
- Enabled the previously skipped test case `latest/postgres/create_index-345.sql`

## Review & Testing Checklist for Human

- [ ] **Run the specific test case** - Verify `yarn test __tests__/kitchen-sink/14-15/latest-postgres-create_index.test.ts` passes and specifically tests the SQL `ALTER INDEX concur_exprs_index_expr ALTER COLUMN 1 SET STATISTICS 100`
- [ ] **Check for other missing fields** - Review the `AlterTableCmd` method to ensure no other fields are missing from the transformation logic (compare against PG14/PG15 type definitions)
- [ ] **Run full test suite** - Execute `yarn test` to ensure no regressions were introduced by preserving this field
- [ ] **Verify pattern consistency** - Confirm the added `num` field handling follows the same conditional preservation pattern as other fields in the method

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    TestFile["__tests__/kitchen-sink/14-15/latest-postgres-create_index.test.ts"]:::context
    SQL["ALTER INDEX ... ALTER COLUMN 1 SET STATISTICS 100"]:::context
    SkipList["test-utils/skip-tests/transformer-errors.ts"]:::minor-edit
    Transformer["src/transformers/v14-to-v15.ts:AlterTableCmd()"]:::major-edit
    
    TestFile --> SQL
    SQL --> Transformer
    SkipList -.-> TestFile
    
    Transformer --> |"Before: drops 'num' field"| BadAST["AST missing 'num': 1"]:::context
    Transformer --> |"After: preserves 'num' field"| GoodAST["AST with 'num': 1"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Link to Devin run**: https://app.devin.ai/sessions/d1e90b8732e442abb6e87fc552d91eb0
- **Requested by**: Dan Lynch (@pyramation)
- **Testing approach**: Used debugging scripts to isolate the transformation issue and verify the fix works correctly
- **Risk level**: Low - targeted fix following established patterns, but reviewer should verify completeness of field handling
