### PR TITLE
chore: align PL/pgSQL and CLI package versions with PG18 (18.0.0)

### DIFF
--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgsql-parse",
-  "version": "1.0.0",
+  "version": "18.0.0",
   "author": "Constructive <developers@constructive.io>",
   "description": "Comment and whitespace preserving PostgreSQL parser",
   "main": "index.js",

--- a/packages/pgsql-cli/package.json
+++ b/packages/pgsql-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pgsql/cli",
-  "version": "2.0.0",
+  "version": "18.0.0",
   "description": "Unified CLI for PostgreSQL AST parsing, deparsing, and code generation",
   "author": "Constructive <developers@constructive.io>",
   "main": "index.js",

--- a/packages/plpgsql-deparser/package.json
+++ b/packages/plpgsql-deparser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plpgsql-deparser",
-  "version": "1.0.0",
+  "version": "18.0.0",
   "author": "Constructive <developers@constructive.io>",
   "description": "PL/pgSQL AST Deparser - Converts PL/pgSQL function ASTs back to SQL",
   "main": "index.js",

--- a/packages/plpgsql-parse/package.json
+++ b/packages/plpgsql-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plpgsql-parse",
-  "version": "1.0.0",
+  "version": "18.0.0",
   "author": "Constructive <developers@constructive.io>",
   "description": "Comment and whitespace preserving PL/pgSQL parser",
   "main": "index.js",

--- a/packages/plpgsql-parser/package.json
+++ b/packages/plpgsql-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plpgsql-parser",
-  "version": "1.0.0",
+  "version": "18.0.0",
   "author": "Constructive <developers@constructive.io>",
   "description": "Combined SQL + PL/pgSQL parser with hydrated ASTs and transform API",
   "main": "index.js",


### PR DESCRIPTION
## Summary
Version-only bump so every package on the PG18 stack shares the `18.x` major, making the PostgreSQL major obvious from the package version:

- `plpgsql-parser`, `plpgsql-deparser`, `plpgsql-parse`, `pgsql-parse`: `1.0.0` → `18.0.0`
- `@pgsql/cli`: `2.0.0` → `18.0.0`

No code changes; internal deps use `workspace:*` so no range updates needed. Intended to be published as `18.0.1` via the next lerna publish.

Link to Devin session: https://app.devin.ai/sessions/064ad193e1c040af8c145d55e07af9b8
Requested by: @pyramation