### PR TITLE
fix(deparser): keep the constraint name on EXCLUDE constraints

### DIFF
--- a/__fixtures__/generated/generated.json
+++ b/__fixtures__/generated/generated.json
@@ -21372,6 +21372,8 @@
   "misc/issues-18.sql": "SELECT (- (-10 - -12))::numeric AS delta",
   "misc/issues-19.sql": "SELECT (- (a.actual_eur - a.budget_eur))::numeric AS delta_eur FROM accounts a",
   "misc/issues-20.sql": "CREATE TABLE test_exclude_where (\n  id uuid PRIMARY KEY,\n  database_id uuid NOT NULL,\n  status text NOT NULL DEFAULT 'pending',\n  EXCLUDE USING btree (database_id WITH =)\n    WHERE (status = 'pending')\n)",
+  "misc/issues-21.sql": "CREATE TABLE test_named_exclude (\n  id uuid PRIMARY KEY,\n  database_id uuid NOT NULL,\n  status text NOT NULL DEFAULT 'pending',\n  CONSTRAINT one_pending_per_database\n    EXCLUDE USING btree (database_id WITH =)\n    WHERE (status = 'pending')\n)",
+  "misc/issues-22.sql": "ALTER TABLE test_named_exclude ADD CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&)",
   "misc/inflection-1.sql": "CREATE SCHEMA inflection",
   "misc/inflection-2.sql": "GRANT USAGE ON SCHEMA inflection TO PUBLIC",
   "misc/inflection-3.sql": "ALTER DEFAULT PRIVILEGES IN SCHEMA inflection \n GRANT EXECUTE ON FUNCTIONS  TO PUBLIC",

--- a/__fixtures__/kitchen-sink/misc/issues.sql
+++ b/__fixtures__/kitchen-sink/misc/issues.sql
@@ -92,3 +92,14 @@ CREATE TABLE test_exclude_where (
   EXCLUDE USING btree (database_id WITH =)
     WHERE (status = 'pending')
 );
+
+-- Named EXCLUDE constraint: the deparser dropped `CONSTRAINT <name>` for CONSTR_EXCLUSION
+CREATE TABLE test_named_exclude (
+  id uuid PRIMARY KEY,
+  database_id uuid NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  CONSTRAINT one_pending_per_database
+    EXCLUDE USING btree (database_id WITH =)
+    WHERE (status = 'pending')
+);
+ALTER TABLE test_named_exclude ADD CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&);

--- a/packages/deparser/__tests__/kitchen-sink/misc-issues.test.ts
+++ b/packages/deparser/__tests__/kitchen-sink/misc-issues.test.ts
@@ -23,6 +23,8 @@ it('misc-issues', async () => {
   "misc/issues-17.sql",
   "misc/issues-18.sql",
   "misc/issues-19.sql",
-  "misc/issues-20.sql"
+  "misc/issues-20.sql",
+  "misc/issues-21.sql",
+  "misc/issues-22.sql"
 ]);
 });

--- a/packages/deparser/src/deparser.ts
+++ b/packages/deparser/src/deparser.ts
@@ -2807,7 +2807,7 @@ export class Deparser implements DeparserVisitor {
     const output: string[] = [];
 
     // Handle constraint name if present
-    if (node.conname && (node.contype === 'CONSTR_CHECK' || node.contype === 'CONSTR_UNIQUE' || node.contype === 'CONSTR_PRIMARY' || node.contype === 'CONSTR_FOREIGN' || node.contype === 'CONSTR_NOTNULL')) {
+    if (node.conname && (node.contype === 'CONSTR_CHECK' || node.contype === 'CONSTR_UNIQUE' || node.contype === 'CONSTR_PRIMARY' || node.contype === 'CONSTR_FOREIGN' || node.contype === 'CONSTR_NOTNULL' || node.contype === 'CONSTR_EXCLUSION')) {
       output.push('CONSTRAINT');
       output.push(QuoteUtils.quoteIdentifier(node.conname));
     }


### PR DESCRIPTION
## Summary

`Constraint()` only emitted `CONSTRAINT <name>` for a whitelist of contypes, and `CONSTR_EXCLUSION` was missing — so a named exclusion constraint silently lost its name on deparse:

```sql
-- in
CONSTRAINT one_pending_per_database EXCLUDE USING btree (database_id WITH =) WHERE (status = 'pending')
-- out (before)
EXCLUDE USING btree (database_id WITH =) WHERE (status = 'pending')
```

That's a real semantic loss: the constraint gets an auto-generated name, so `ALTER TABLE ... DROP CONSTRAINT one_pending_per_database` and migration diffs break. Found while chasing the `⚠️ AST round-trip diff detected!` warning during `pgpm package` in constructive-db (`metaschema_public.database_transfer`).

```diff
-if (node.conname && (… || node.contype === 'CONSTR_NOTNULL')) {
+if (node.conname && (… || node.contype === 'CONSTR_NOTNULL' || node.contype === 'CONSTR_EXCLUSION')) {
```

Fixture added to `__fixtures__/kitchen-sink/misc/issues.sql` (inline named EXCLUDE + `ALTER TABLE ADD CONSTRAINT ... EXCLUDE USING gist`), regenerated via `npm run kitchen-sink`. Full deparser suite passes (295 suites / 715 tests).


Link to Devin session: https://app.devin.ai/sessions/5cfcc6690b574cdd96de080ee3b94b4e
Requested by: @pyramation